### PR TITLE
fix: Eventモデルに合わせて修正

### DIFF
--- a/TikokulympicBeta/Models/Event.swift
+++ b/TikokulympicBeta/Models/Event.swift
@@ -12,7 +12,7 @@ struct Event: Decodable, Identifiable {
     let locationName: String
     let latitude: Double
     let longitude: Double
-    let cost: Double
+    let cost: Int
     let message: String
     let options: [Option]?
     private enum CodingKeys: String, CodingKey {

--- a/TikokulympicBeta/Services/EventService.swift
+++ b/TikokulympicBeta/Services/EventService.swift
@@ -16,10 +16,10 @@ class EventService {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
         
-        let startTime = dateFormatter.string(from: event.startTime)
-        let endTime = dateFormatter.string(from: event.endTime)
-        let closingTime = dateFormatter.string(from: event.closingTime)
-        
+        let startTime = dateFormatter.string(from: event.startDateTime)
+        let endTime = dateFormatter.string(from: event.endDateTime)
+        let closingTime = dateFormatter.string(from: event.closingDateTime)
+
         let request = EventEditingRequest(
             title: event.title,
             description: event.description,
@@ -28,11 +28,11 @@ class EventService {
             end_time: endTime,
             closing_time: closingTime,
             location_name: event.locationName,
-            cost: event.cost,
+            cost: Int(event.cost) ?? 0,
             message: event.message,
-            author_id: event.managerId,
-            latitude: event.latitude,
-            longitude: event.longitude
+            author_id: event.author?.authorId ?? 0,
+            latitude: "\(event.latitude)",
+            longitude:"\(event.longitude)"
         )
         
         do {

--- a/TikokulympicBeta/Views/EventList/EventEditViewModel.swift
+++ b/TikokulympicBeta/Views/EventList/EventEditViewModel.swift
@@ -39,18 +39,18 @@ class EventEditViewModel: ObservableObject {
         let longitude = "135.5612"
         
         let newEvent = Event(
+            author: nil,
             title: eventName,
             description: eventDescription,
             isAllDay: false,
-            startTime: startDateTime,
-            endTime: endDateTime,
-            closingTime: applicationDeadline,
+            startDateTime: startDateTime,
+            endDateTime: endDateTime,
+            closingDateTime: applicationDeadline,
             locationName: location,
-            cost: cost,
+            latitude: 35.00,
+            longitude: 36.00,
+            cost: Int(fee) ?? 0,
             message: contactInfo,
-            managerId: userid,
-            latitude: latitude,
-            longitude: longitude,
             options: options
         )
 

--- a/TikokulympicBeta/Views/EventList/EventListViewModel.swift
+++ b/TikokulympicBeta/Views/EventList/EventListViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class EventListViewModel: ObservableObject {
     @Published var events: [Event] = []
-    let service = EventService.shered
+    let service = EventService.shared
 
 
     @MainActor


### PR DESCRIPTION
Eventモデルに違いがあり，送るリクエスト自体がずれていたので修正
タイポしてたので修正

モデルが相違あると不整合増えそうなのでどっちに統一するかはお任せ致しやす．
